### PR TITLE
fix: 修复`README.md`中的源码使用部分的错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ sudo pip3 install PyQt6 PySide6 pyserial esptool -i https://pypi.tuna.tsinghua.e
 
 ```
 cd fishbot_tool/fishbot_tool/
-sudo python3 main.py
+sudo DISPLAY=unix$DISPLAY python3 main.py
 ```
 
 


### PR DESCRIPTION
sudo执行时传入环境变量`DISPLAY`，否则Qt会提示下面的错误：
```
qt.qpa.xcb: could not connect to display 
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: wayland, minimalegl, wayland-egl, eglfs, minimal, xcb, vnc, vkkhrdisplay, linuxfb, offscreen.

Aborted
```